### PR TITLE
Feature/update to v19 xbmcvfs

### DIFF
--- a/resources/lib/screensaver.py
+++ b/resources/lib/screensaver.py
@@ -125,7 +125,7 @@ class Kaster(xbmcgui.WindowXMLDialog):
             self.images = json.loads(images)
         # Check if we have images to append
         if kodiutils.get_setting_as_int("screensaver-mode") == 1 or kodiutils.get_setting_as_int("screensaver-mode") == 2 and not override:
-            if kodiutils.get_setting("my-pictures-folder") and xbmcvfs.exists(xbmc.translatePath(kodiutils.get_setting("my-pictures-folder"))):
+            if kodiutils.get_setting("my-pictures-folder") and xbmcvfs.exists(xbmcvfs.translatePath(kodiutils.get_setting("my-pictures-folder"))):
                 for image in self.utils.get_own_pictures(kodiutils.get_setting("my-pictures-folder")):
                     self.images.append(image)
             else:

--- a/resources/lib/screensaverutils.py
+++ b/resources/lib/screensaverutils.py
@@ -31,9 +31,9 @@ class ScreenSaverUtils:
         self.images.append(image)
 
     def __get_images_recursively(self, path):
-        folders, files = xbmcvfs.listdir(xbmc.translatePath(path))
+        folders, files = xbmcvfs.listdir(xbmcvfs.translatePath(path))
         for _file in files:
-            self.__append_image(os.path.join(xbmc.translatePath(path), _file))
+            self.__append_image(os.path.join(xbmcvfs.translatePath(path), _file))
         if folders:
             for folder in folders:
                 path = os.path.join(path,folder)
@@ -46,7 +46,7 @@ class ScreenSaverUtils:
         self.__reset_images()
         images_dict = {}
 
-        image_file = os.path.join(xbmc.translatePath(path), "images.json")
+        image_file = os.path.join(xbmcvfs.translatePath(path), "images.json")
         if xbmcvfs.exists(image_file):
             f = xbmcvfs.File(image_file)
             try:
@@ -55,7 +55,7 @@ class ScreenSaverUtils:
                kodiutils.log(kodiutils.get_string(32010), xbmc.LOGERROR)
             f.close()
 
-        self.__get_images_recursively(xbmc.translatePath(path))
+        self.__get_images_recursively(xbmcvfs.translatePath(path))
 
         for _file in self.get_all_images():
             if _file.lower().endswith(('.png', '.jpg', '.jpeg')):
@@ -65,7 +65,7 @@ class ScreenSaverUtils:
                 }
                 if images_dict:
                     for image in images_dict:
-                        if "image" in list(image.keys()) and os.path.join(xbmc.translatePath(path),image["image"]) == _file:
+                        if "image" in list(image.keys()) and os.path.join(xbmcvfs.translatePath(path),image["image"]) == _file:
                             if "line1" in list(image.keys()):
                                 returned_dict["line1"] = image["line1"]
                             if "line2" in list(image.keys()):


### PR DESCRIPTION
Since Kodi version 19, `translatePath` has been moved to the `xbmcvfs` module instead of `xbmc`, and as of version 20 it is no longer available on `xbmc` at all, and so the current version (1.3.6) breaks on on Kodi Nexus. 

This PR changes the call to `translatePath` to use the `xbmcvfs` module and should be made available at least on the [Nexus Add-on repository](https://kodi.tv/addons/nexus/screensaver.kaster/) (I'm not familiar with official add-on development, so I don't know if having different versions for different Kodi add-on repository versions make sense).