### PR TITLE
Show fair number of personal images

### DIFF
--- a/resources/lib/screensaverutils.py
+++ b/resources/lib/screensaverutils.py
@@ -58,7 +58,7 @@ class ScreenSaverUtils:
         self.__get_images_recursively(xbmc.translatePath(path))
 
         for _file in self.get_all_images():
-            if _file.lower().endswith(('.png', '.jpg', '.jpeg')):
+            if _file.lower().endswith(('.png', '.jpg', '.jpeg', '.heic')):
                 returned_dict = {
                     "url": _file,
                     "private": True


### PR DESCRIPTION
I've been using Kaster as TV picture frame and it's awesome.

In my use case, I'm mixing personal images with the beautiful chromecast images. However, since chromecast has over 900 images, it used to take a very a long time until we get to see one of our own.

In this MR, I'm proposing a few updates to make this more usable:
 - If personal images are configured, it makes it so that about the same number of google images and personal images are shown, so that you get 50/50 chance to see one or the other
 - It fixes a bug where if one of the chromecast images was no longer available, it got stuck trying to get it over and over
 - It adds support for a picture format used by iphone, apparently

I hope this is useful / makes sense. Happy to address any comments / suggestions.